### PR TITLE
Add phased/unphased support across simulation, sstar, and QR workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-detectable=false
+*.py linguist-detectable=true

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -23,6 +23,7 @@ import numpy as np
 
 TRAINING_REP = 1000
 TEST_REP = 10
+PHASE_STATES = ["phased", "unphased"]
 
 np.random.seed(3821)
 rng = np.random.default_rng()
@@ -41,14 +42,16 @@ cutoffs = np.concatenate([np.array([0.001, 0.01]), cutoffs, np.array([0.99, 0.99
 rule all:
     input:
         expand(
-            "results/{qr_model}/rep_{test_rep}/{qr_model}.{feature_set}.q_{quantile}.rep_{test_rep}.perf.tsv",
+            "results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
             qr_model=["quantile", "gradient", "qrf"],
             feature_set=["sstar_snp", "region_snp", "both"],
+            phase_state=PHASE_STATES,
             quantile=cutoffs,
             test_rep=range(TEST_REP),
         ),
         expand(
-            "results/sstar/rep_{test_rep}/sstar.phased.q_{quantile}.rep_{test_rep}.perf.tsv",
+            "results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+            phase_state=PHASE_STATES,
             quantile=cutoffs,
             test_rep=range(TEST_REP),
         ),

--- a/workflow/rules/qr.smk
+++ b/workflow/rules/qr.smk
@@ -23,7 +23,7 @@ rule run_qr:
         training_data=rules.merge_training_sstar_score.output.scores,
         test_data=rules.sstar_score.output.scores,
     output:
-        preds="results/{qr_model}/rep_{test_rep}/{qr_model}.{feature_set}.q_{quantile}.rep_{test_rep}.preds.tsv",
+        preds="results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.preds.tsv",
     resources:
         time=720, mem_gb=16,
     conda:
@@ -36,19 +36,21 @@ rule get_qr_inferred_tracts:
     input:
         preds=rules.run_qr.output.preds,
     output:
-        bed="results/{qr_model}/rep_{test_rep}/{qr_model}.{feature_set}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
+        bed="results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
+    params:
+        phased=lambda wildcards: wildcards.phase_state == "phased",
     shell:
         r"""
-        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$9 {{print $1,$2,$3,$4}}' {input.preds} | sed 's/hap//' > {output.bed}
+        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$9 {{print $1,$2,$3,$4}}' {input.preds} | awk 'BEGIN{{FS=OFS="\t"}} {{if ("{params.phased}"=="True") gsub(/hap/, "", $4); print}}' > {output.bed}
         """
 
 
 rule evaluate_qr:
     input:
-        true_tracts=rules.simulate_test_data.output.bed,
+        true_tracts="results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.{phase_state}.bed",
         inferred_tracts=rules.get_qr_inferred_tracts.output.bed,
     output:
-        tsv="results/{qr_model}/rep_{test_rep}/{qr_model}.{feature_set}.q_{quantile}.rep_{test_rep}.perf.tsv",
+        tsv="results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
     params:
         length_bp=200_000_000,
         cutoff="{quantile}",

--- a/workflow/rules/simulation.smk
+++ b/workflow/rules/simulation.smk
@@ -24,7 +24,8 @@ rule simulate_training_data:
     output:
         ts=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ts"),
         vcf=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.vcf"),
-        bed=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.true.tracts.bed"),
+        bed_phased=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.true.tracts.phased.bed"),
+        bed_unphased=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.true.tracts.unphased.bed"),
         ref_list=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ref.list"),
         tgt_list=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.tgt.list"),
         src_list=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src.list"),
@@ -39,6 +40,7 @@ rule simulate_training_data:
         ref_id="Reference",
         tgt_id="Target",
         src_id="Source",
+        ploidy=2,
         seed=lambda wildcards: training_seed_list[int(wildcards.test_rep)][int(wildcards.training_rep)],
     resources:
         mem_gb=16,
@@ -52,7 +54,8 @@ rule simulate_test_data:
     output:
         ts=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.ts"),
         vcf=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.vcf"),
-        bed=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.bed"),
+        bed_phased=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.phased.bed"),
+        bed_unphased=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.unphased.bed"),
         ref_list=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.ref.list"),
         tgt_list=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.tgt.list"),
         src_list=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.src.list"),
@@ -67,6 +70,7 @@ rule simulate_test_data:
         ref_id="Reference",
         tgt_id="Target",
         src_id="Source",
+        ploidy=2,
         seed=lambda wildcards: test_seed_list[int(wildcards.test_rep)],
     resources:
         time=360, mem_gb=16,
@@ -104,10 +108,11 @@ rule calc_training_sstar_score:
         ref_list=rules.simulate_training_data.output.ref_list,
         tgt_list=rules.simulate_training_data.output.tgt_list,
     output:
-        score=temp("results/simulation/training/rep_{test_rep}/sstar.phased.rep_{training_rep}.scores.tsv"),
+        score=temp("results/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{training_rep}.scores.tsv"),
     params:
         win_len=50000,
         win_step=50000,
+        phased_flag=lambda wildcards: "--phased" if wildcards.phase_state == "phased" else "",
     resources:
         mem_gb=16, cpus=4,
     conda:
@@ -122,19 +127,19 @@ rule calc_training_sstar_score:
           --thread {resources.cpus} \
           --win-len {params.win_len} \
           --win-step {params.win_step} \
-          --phased \
+          {params.phased_flag} \
         """
 
 
 rule merge_training_sstar_score:
     input:
         scores=expand(
-            "results/simulation/training/rep_{test_rep}/sstar.phased.rep_{training_rep}.scores.tsv",
+            "results/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{training_rep}.scores.tsv",
             training_rep=range(TRAINING_REP),
-            test_rep=range(TEST_REP),
+            allow_missing=True,
         ),
     output:
-        scores="results/simulation/training/rep_{test_rep}/sstar.phased.rep_{test_rep}.training.scores.tsv",
+        scores="results/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.training.scores.tsv",
     shell:
         """
         awk 'FNR==1 && NR!=1 {{next}} {{print}}' {input.scores} > {output.scores}

--- a/workflow/rules/sstar.smk
+++ b/workflow/rules/sstar.smk
@@ -29,10 +29,11 @@ rule sstar_score:
         ref_list=rules.simulate_test_data.output.ref_list,
         tgt_list=rules.simulate_test_data.output.tgt_list,
     output:
-        scores="results/simulation/test/rep_{test_rep}/sstar.phased.rep_{test_rep}.scores.tsv",
+        scores="results/simulation/test/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.scores.tsv",
     params:
         win_len=50000,
         win_step=50000,
+        phased_flag=lambda wildcards: "--phased" if wildcards.phase_state == "phased" else "",
     resources:
         mem_gb=16, cpus=4,
     conda:
@@ -47,7 +48,7 @@ rule sstar_score:
           --thread {resources.cpus} \
           --win-len {params.win_len} \
           --win-step {params.win_step} \
-          --phased \
+          {params.phased_flag} \
         """
 
 
@@ -55,10 +56,10 @@ rule sstar_quantile:
     input:
         model="config/ArchIE_3D19_wo_introgression.yaml",
     output:
-        quantile="results/sstar/rep_{test_rep}/quantile.summary.txt",
+        quantile="results/sstar/{phase_state}/rep_{test_rep}/quantile.summary.txt",
     params:
         ms_dir="resources/msdir",
-        output_dir="results/sstar/rep_{test_rep}",
+        output_dir="results/sstar/{phase_state}/rep_{test_rep}",
     resources:
         time=360, mem_gb=128, cpus=32,
     conda:
@@ -89,7 +90,9 @@ rule sstar_threshold:
         scores=rules.sstar_score.output.scores,
         quantile=rules.sstar_quantile.output.quantile,
     output:
-        preds="results/sstar/rep_{test_rep}/sstar.phased.q_{quantile}.rep_{test_rep}.preds.tsv",
+        preds="results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.preds.tsv",
+    params:
+        phased_flag=lambda wildcards: "--phased" if wildcards.phase_state == "phased" else "",
     conda:
         "../envs/sstar.yaml",
     shell:
@@ -101,7 +104,7 @@ rule sstar_threshold:
           --quantile {wildcards.quantile} \
           --output {output.preds} \
           --k 8 \
-          --phased
+          {params.phased_flag}
         """
 
 
@@ -109,19 +112,21 @@ rule get_sstar_inferred_tracts:
     input:
         preds=rules.sstar_threshold.output.preds,
     output:
-        bed="results/sstar/rep_{test_rep}/sstar.phased.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
+        bed="results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
+    params:
+        phased=lambda wildcards: wildcards.phase_state == "phased",
     shell:
         r"""
-        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$6 {{print $1,$2,$3,$4}}' {input.preds} | sed 's/hap//' > {output.bed}
+        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$6 {{print $1,$2,$3,$4}}' {input.preds} | awk 'BEGIN{{FS=OFS="\t"}} {{if ("{params.phased}"=="True") gsub(/hap/, "", $4); print}}' > {output.bed}
         """
 
 
 rule evaluate_sstar:
     input:
-        true_tracts=rules.simulate_test_data.output.bed,
+        true_tracts="results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.{phase_state}.bed",
         inferred_tracts=rules.get_sstar_inferred_tracts.output.bed,
     output:
-        tsv="results/sstar/rep_{test_rep}/sstar.phased.q_{quantile}.rep_{test_rep}.perf.tsv",
+        tsv="results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
     params:
         length_bp=200_000_000,
         cutoff="{quantile}",

--- a/workflow/scripts/msprime_simulation.py
+++ b/workflow/scripts/msprime_simulation.py
@@ -1,27 +1,77 @@
-# Copyright 2025 Xin Huang
-#
-# GNU General Public License v3.0
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, please see
-#
-#    https://www.gnu.org/licenses/gpl-3.0.en.html
+"""
+Copyright 2025 Xin Huang
 
+GNU General Public License v3.0
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, please see
+
+   https://www.gnu.org/licenses/gpl-3.0.en.html
+"""
 
 import demes
 import msprime
 import tskit
 import pyranges as pr
+from typing import Optional
+
+
+def get_haplotype_index(
+    ts: tskit.TreeSequence,
+    node_id: int,
+    expected_ploidy: Optional[int] = None,
+) -> int:
+    """
+    Get 1-based haplotype index of a node within its associated individual.
+
+    Parameters
+    ----------
+    ts : tskit.TreeSequence
+        Tree sequence containing node and individual tables.
+    node_id : int
+        Node identifier whose haplotype index will be computed.
+    expected_ploidy : int, optional
+        Expected number of nodes associated with the node's individual. If
+        provided, the function validates that ``len(individual.nodes)`` equals
+        this value.
+
+    Returns
+    -------
+    int
+        One-based position of ``node_id`` in ``ts.individual(ind_id).nodes``.
+
+    Raises
+    ------
+    ValueError
+        If ``node_id`` has no associated individual, if the individual's node
+        count does not match ``expected_ploidy``, or if ``node_id`` is not found
+        in the associated individual's node list.
+    """
+    ind_id = ts.node(node_id).individual
+    if ind_id == tskit.NULL:
+        raise ValueError(f"Node {node_id} has no associated individual.")
+
+    ind_nodes = list(ts.individual(ind_id).nodes)
+    if expected_ploidy is not None and len(ind_nodes) != expected_ploidy:
+        raise ValueError(
+            f"Individual {ind_id} has {len(ind_nodes)} nodes, expected {expected_ploidy}."
+        )
+    try:
+        return ind_nodes.index(node_id) + 1
+    except ValueError as e:
+        raise ValueError(
+            f"Node {node_id} is not listed in individual {ind_id} nodes."
+        ) from e
 
 
 def simulate(
@@ -151,6 +201,7 @@ def get_true_tracts(
     ts: tskit.TreeSequence,
     tgt_id: str,
     src_id: str,
+    is_phased: bool = True,
     ploidy: int = 2,
 ) -> str:
     """
@@ -163,7 +214,10 @@ def get_true_tracts(
 
         Chromosome  Start  End  Sample
 
-    where `Sample` is formatted as `tsk_{individual_id}_{hap_index}`.
+    where `Sample` is formatted as:
+      - `tsk_{individual_id}_{hap_index}` when `is_phased=True`;
+      - `tsk_{individual_id}` when `is_phased=False` (unphased, i.e., union
+        across haplotypes per individual after merge).
 
     Parameters
     ----------
@@ -173,10 +227,10 @@ def get_true_tracts(
         Name of the target population (as stored in ts.populations().metadata["name"]).
     src_id : str
         Name of the source population (as stored in ts.populations().metadata["name"]).
+    is_phased : bool, optional
+        Whether to output haplotype-level sample identifiers. Default is True.
     ploidy : int, optional
-        Ploidy of individuals in the tree sequence, used to derive haplotype index
-        from sample node IDs. Default is 2.
-
+        Ploidy used to infer haplotype index in phased mode. Default is 2.
     Returns
     -------
     str
@@ -208,7 +262,11 @@ def get_true_tracts(
                         right = (
                             m.right if m.right < t.interval.right else t.interval.right
                         )
-                        sample_id = f"tsk_{ts.node(n).individual}_{int(n%ploidy+1)}"
+                        if is_phased:
+                            hap_index = get_haplotype_index(ts, n, ploidy)
+                            sample_id = f"tsk_{ts.node(n).individual}_{hap_index}"
+                        else:
+                            sample_id = f"tsk_{ts.node(n).individual}"
                         tracts += f"1\t{int(left)}\t{int(right)}\t{sample_id}\n"
 
     return tracts
@@ -246,14 +304,22 @@ create_sample_lists(
     src_list=snakemake.output.src_list,
 )
 
-true_tracts = get_true_tracts(
-    ts=ts,
-    tgt_id=snakemake.params.tgt_id,
-    src_id=snakemake.params.src_id,
-)
+true_tract_output = {
+    "phased": snakemake.output.bed_phased,
+    "unphased": snakemake.output.bed_unphased,
+}
 
-true_tracts = pr.from_string(true_tracts).merge(by="Sample")
-if true_tracts.empty:
-    open(snakemake.output.bed, "w").close()
-else:
-    true_tracts.to_csv(snakemake.output.bed, sep="\t", header=False)
+for phased_status in ["phased", "unphased"]:
+    true_tracts = get_true_tracts(
+        ts=ts,
+        tgt_id=snakemake.params.tgt_id,
+        src_id=snakemake.params.src_id,
+        is_phased=phased_status == "phased",
+        ploidy=int(snakemake.params.ploidy),
+    )
+
+    true_tracts = pr.from_string(true_tracts).merge(by="Sample")
+    if true_tracts.empty:
+        open(true_tract_output[phased_status], "w").close()
+    else:
+        true_tracts.to_csv(true_tract_output[phased_status], sep="\t", header=False)


### PR DESCRIPTION
### Motivation
- Enable the pipeline to process both phased and unphased data and produce separate outputs for each phase state.
- Ensure true-tract extraction can emit haplotype-level IDs for phased data and individual-level IDs for unphased data while respecting ploidy.
- Propagate phase-state information through sstar scoring/thresholding and quantile/regression (QR) evaluation so performance is computed per phase state.

### Description
- Introduce `PHASE_STATES` and add a `phase_state` wildcard to `Snakefile` expands and output paths so results are generated for both `phased` and `unphased` states.
- Update `rules/sstar.smk` and `rules/qr.smk` to accept `phase_state`, pass a `phased_flag` to `sstar` commands, alter inferred-tract extraction to conditionally strip `hap` labels using `awk`, and include `phase_state` in prediction/evaluation output paths.
- Modify `rules/simulation.smk` to produce `true.tracts.phased.bed` and `true.tracts.unphased.bed`, add `ploidy` param to simulation rules, and merge training scores per `phase_state`.
- Extend `workflow/scripts/msprime_simulation.py` with `get_haplotype_index` and update `get_true_tracts` to support `is_phased` mode and to write both phased and unphased bed outputs, using `ploidy` when computing haplotype indices.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eefa2515a8832c8e71a116969e3fb9)