### PR TITLE
Parameterize workflow by demographic model and sample sizes; centralize simulation params

### DIFF
--- a/config/BonoboGhost_4K19.yaml
+++ b/config/BonoboGhost_4K19.yaml
@@ -1,0 +1,43 @@
+time_units: generations
+generation_time: 1
+demes:
+  - name: Anc
+    epochs:
+      - {end_time: 140000, start_size: 10000}
+  - name: Anc_Pan
+    ancestors: [Anc]
+    epochs:
+      - {end_time: 79600, start_size: 11600}
+  - name: Ghost
+    ancestors: [Anc]
+    epochs:
+      - {end_time: 0, start_size: 10000}
+  - name: Anc_Chimp
+    ancestors: [Anc_Pan]
+    epochs:
+      - {end_time: 28000, start_size: 10200}
+  - name: Bonobo
+    ancestors: [Anc_Pan]
+    epochs:
+      - {end_time: 12320, start_size: 3700}
+      - {end_time: 0, start_size: 29100}
+  - name: Central
+    ancestors: [Anc_Chimp]
+    epochs:
+      - {end_time: 15120, start_size: 24900}
+      - {end_time: 0, start_size: 65900}
+  - name: Western
+    ancestors: [Anc_Chimp]
+    epochs:
+      - {end_time: 10440, start_size: 8000}
+      - {end_time: 0, start_size: 9200}
+migrations:
+  - demes: [Bonobo, Anc_Chimp]
+    rate: 1e-07
+    start_time: 60000.0
+    end_time: 48000.0
+  - {source: Ghost, dest: Bonobo, start_time: 20001.0, end_time: 20000.0, rate: 0.02}
+  - {source: Bonobo, dest: Central, start_time: 6203.0, end_time: 6202.0, rate: 0.00125}
+  - {source: Central, dest: Bonobo, start_time: 6203.0, end_time: 6202.0, rate: 0.001}
+  - {source: Central, dest: Western, start_time: 4004, end_time: 4003.0, rate: 0.015}
+  - {source: Western, dest: Central, start_time: 4004, end_time: 4003.0, rate: 0.005}

--- a/config/BonoboGhost_4K19_wo_introgression.yaml
+++ b/config/BonoboGhost_4K19_wo_introgression.yaml
@@ -1,0 +1,42 @@
+time_units: generations
+generation_time: 1
+demes:
+  - name: Anc
+    epochs:
+      - {end_time: 140000, start_size: 10000}
+  - name: Anc_Pan
+    ancestors: [Anc]
+    epochs:
+      - {end_time: 79600, start_size: 11600}
+  - name: Ghost
+    ancestors: [Anc]
+    epochs:
+      - {end_time: 0, start_size: 10000}
+  - name: Anc_Chimp
+    ancestors: [Anc_Pan]
+    epochs:
+      - {end_time: 28000, start_size: 10200}
+  - name: Bonobo
+    ancestors: [Anc_Pan]
+    epochs:
+      - {end_time: 12320, start_size: 3700}
+      - {end_time: 0, start_size: 29100}
+  - name: Central
+    ancestors: [Anc_Chimp]
+    epochs:
+      - {end_time: 15120, start_size: 24900}
+      - {end_time: 0, start_size: 65900}
+  - name: Western
+    ancestors: [Anc_Chimp]
+    epochs:
+      - {end_time: 10440, start_size: 8000}
+      - {end_time: 0, start_size: 9200}
+migrations:
+  - demes: [Bonobo, Anc_Chimp]
+    rate: 1e-07
+    start_time: 60000.0
+    end_time: 48000.0
+  - {source: Bonobo, dest: Central, start_time: 6203.0, end_time: 6202.0, rate: 0.00125}
+  - {source: Central, dest: Bonobo, start_time: 6203.0, end_time: 6202.0, rate: 0.001}
+  - {source: Central, dest: Western, start_time: 4004, end_time: 4003.0, rate: 0.015}
+  - {source: Western, dest: Central, start_time: 4004, end_time: 4003.0, rate: 0.005}

--- a/config/HumanNeanderthal_4G21.yaml
+++ b/config/HumanNeanderthal_4G21.yaml
@@ -1,0 +1,37 @@
+# Human-Neantherthal introgression model
+description:
+  A composite hominin model with demographic parameters taken from
+  Gower et al. (2021).
+
+time_units: generations
+
+doi:
+  - https://doi.org/10.7554/eLife.64669
+
+demes:
+  - name: Anc
+    epochs:
+      - end_time: 2265.5172413793102
+        start_size: 18500.0
+  - name: Nea
+    start_time: 18965.51724137931
+    ancestors: [Anc]
+    epochs:
+      - start_size: 3400.0
+  - name: CEU
+    ancestors: [Anc]
+    epochs:
+      - end_time: 1100.0
+        start_size: 1080.0
+      - start_size: 1450.0
+        end_size: 13377.357734109575
+  - name: YRI
+    ancestors: [Anc]
+    epochs:
+      - start_size: 27000.0
+
+pulses:
+  - sources: [Nea]
+    dest: CEU
+    time: 1896.551724137931
+    proportions: [0.0225]

--- a/config/HumanNeanderthal_4G21_wo_introgression.yaml
+++ b/config/HumanNeanderthal_4G21_wo_introgression.yaml
@@ -1,0 +1,31 @@
+# Human-Neantherthal introgression model
+description:
+  A composite hominin model with demographic parameters taken from
+  Gower et al. (2021).
+
+time_units: generations
+
+doi:
+  - https://doi.org/10.7554/eLife.64669
+
+demes:
+  - name: Anc
+    epochs:
+      - end_time: 2265.5172413793102
+        start_size: 18500.0
+  - name: Nea
+    start_time: 18965.51724137931
+    ancestors: [Anc]
+    epochs:
+      - start_size: 3400.0
+  - name: CEU
+    ancestors: [Anc]
+    epochs:
+      - end_time: 1100.0
+        start_size: 1080.0
+      - start_size: 1450.0
+        end_size: 13377.357734109575
+  - name: YRI
+    ancestors: [Anc]
+    epochs:
+      - start_size: 27000.0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -18,12 +18,69 @@
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
 
+from dataclasses import dataclass
+
 import numpy as np
 
 
 TRAINING_REP = 1000
 TEST_REP = 10
+N_REP = 10
+DEMOGRAPHIC_MODELS = [
+    #"ArchIE_3D19",
+    #"HumanNeanderthal_4G21",
+    "BonoboGhost_4K19",
+]
 PHASE_STATES = ["phased", "unphased"]
+N_REFS = [50]
+N_TGTS = [50]
+N_SRCS = [0]
+LENGTH_BPS = {
+    "training": 50_000,
+    "test": 200_000_000,
+}
+
+
+@dataclass(frozen=True)
+class PopConfig:
+    ref: str
+    tgt: str
+    src: str
+    ref_index: int
+    tgt_index: int
+    mut_rate: float
+    rec_rate: float
+
+
+POP_CONFIGS = {
+    "ArchIE_3D19": PopConfig(
+        ref="Reference",
+        tgt="Target",
+        src="Source",
+        ref_index=3,
+        tgt_index=4,
+        mut_rate=1.25e-8,
+        rec_rate=1.0e-8,
+    ),
+    "HumanNeanderthal_4G21": PopConfig(
+        ref="YRI",
+        tgt="CEU",
+        src="Nea",
+        ref_index=4,
+        tgt_index=3,
+        mut_rate=1.29e-8,
+        rec_rate=1e-8,
+    ),
+    "BonoboGhost_4K19": PopConfig(
+        ref="Western",
+        tgt="Bonobo",
+        src="Ghost",
+        ref_index=7,
+        tgt_index=5,
+        mut_rate=1.2e-8,
+        rec_rate=0.7e-8,
+    ),
+}
 
 np.random.seed(3821)
 rng = np.random.default_rng()
@@ -34,6 +91,10 @@ all_seeds = rng.choice(
 ) + 1
 training_seed_list = all_seeds[:TEST_REP * TRAINING_REP].reshape(TEST_REP, TRAINING_REP).tolist()
 test_seed_list = all_seeds[TEST_REP * TRAINING_REP:].tolist()
+seed_lists = {
+    "training": training_seed_list,
+    "test": test_seed_list,
+}
 
 cutoffs = np.arange(0.1, 1.0, 0.1).round(1)
 cutoffs = np.concatenate([np.array([0.001, 0.01]), cutoffs, np.array([0.99, 0.999, 0.9999, 0.99999])])
@@ -42,7 +103,11 @@ cutoffs = np.concatenate([np.array([0.001, 0.01]), cutoffs, np.array([0.99, 0.99
 rule all:
     input:
         expand(
-            "results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+            demog_model=DEMOGRAPHIC_MODELS,
+            n_ref=N_REFS,
+            n_tgt=N_TGTS,
+            n_src=N_SRCS,
             qr_model=["quantile", "gradient", "qrf"],
             feature_set=["sstar_snp", "region_snp", "both"],
             phase_state=PHASE_STATES,
@@ -50,13 +115,18 @@ rule all:
             test_rep=range(TEST_REP),
         ),
         expand(
-            "results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+            demog_model=DEMOGRAPHIC_MODELS,
+            n_ref=N_REFS,
+            n_tgt=N_TGTS,
+            n_src=N_SRCS,
             phase_state=PHASE_STATES,
             quantile=cutoffs,
             test_rep=range(TEST_REP),
         ),
 
 
+include: "rules/common.smk"
 include: "rules/simulation.smk"
 include: "rules/sstar.smk"
 include: "rules/qr.smk"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,0 +1,49 @@
+# Copyright 2026 Xin Huang and Andrea Koca
+#
+# GNU General Public License v3.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, please see
+#
+#    https://www.gnu.org/licenses/gpl-3.0.en.html
+
+
+def get_pop_config(wildcards):
+    return POP_CONFIGS[wildcards.demog_model]
+
+
+def get_simulation_params(wildcards, split):
+    pop = get_pop_config(wildcards)
+    if split == "training":
+        seed = seed_lists[split][int(wildcards.test_rep)][int(wildcards.training_rep)]
+    else:
+        seed = seed_lists[split][int(wildcards.test_rep)]
+
+    return {
+        "length_bp": LENGTH_BPS[split],
+        "ploidy": 2,
+        "seed": seed,
+        "mu": pop.mut_rate,
+        "rho": pop.rec_rate,
+        "ref_id": pop.ref,
+        "tgt_id": pop.tgt,
+        "src_id": pop.src,
+    }
+
+
+def get_sample_size(wildcards):
+    return {
+        "total": 2*(int(wildcards.n_ref)+int(wildcards.n_tgt)),
+        "ref": 2*(int(wildcards.n_ref)),
+        "tgt": 2*(int(wildcards.n_tgt)),
+    }

--- a/workflow/rules/qr.smk
+++ b/workflow/rules/qr.smk
@@ -23,7 +23,7 @@ rule run_qr:
         training_data=rules.merge_training_sstar_score.output.scores,
         test_data=rules.sstar_score.output.scores,
     output:
-        preds="results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.preds.tsv",
+        preds="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.preds.tsv",
     resources:
         time=720, mem_gb=16,
     conda:
@@ -36,21 +36,19 @@ rule get_qr_inferred_tracts:
     input:
         preds=rules.run_qr.output.preds,
     output:
-        bed="results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
-    params:
-        phased=lambda wildcards: wildcards.phase_state == "phased",
+        bed="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
     shell:
         r"""
-        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$9 {{print $1,$2,$3,$4}}' {input.preds} | awk 'BEGIN{{FS=OFS="\t"}} {{if ("{params.phased}"=="True") gsub(/hap/, "", $4); print}}' > {output.bed}
+        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$9 {{print $1,$2,$3,$4}}' {input.preds} | awk 'BEGIN{{FS=OFS="\t"}} {{if ("{wildcards.phase_state}"=="phased") gsub(/hap/, "", $4); print}}' > {output.bed}
         """
 
 
 rule evaluate_qr:
     input:
-        true_tracts="results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.{phase_state}.bed",
+        true_tracts="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.{phase_state}.bed",
         inferred_tracts=rules.get_qr_inferred_tracts.output.bed,
     output:
-        tsv="results/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+        tsv="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{feature_set}.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
     params:
         length_bp=200_000_000,
         cutoff="{quantile}",

--- a/workflow/rules/simulation.smk
+++ b/workflow/rules/simulation.smk
@@ -20,28 +20,18 @@
 
 rule simulate_training_data:
     input:
-        demes="config/ArchIE_3D19_wo_introgression.yaml",
+        demes="config/{demog_model}_wo_introgression.yaml",
     output:
-        ts=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ts"),
-        vcf=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.vcf"),
-        bed_phased=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.true.tracts.phased.bed"),
-        bed_unphased=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.true.tracts.unphased.bed"),
-        ref_list=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ref.list"),
-        tgt_list=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.tgt.list"),
-        src_list=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src.list"),
-        seed_file=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.seedmsprime"),
+        ts=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ts"),
+        vcf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.vcf"),
+        bed_phased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.true.tracts.phased.bed"),
+        bed_unphased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.true.tracts.unphased.bed"),
+        ref_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ref.list"),
+        tgt_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.tgt.list"),
+        src_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src.list"),
+        seed_file=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.seedmsprime"),
     params:
-        n_ref=50,
-        n_tgt=50,
-        n_src=0,
-        length_bp=50_000,
-        mu=1.2e-8,
-        rho=1e-8,
-        ref_id="Reference",
-        tgt_id="Target",
-        src_id="Source",
-        ploidy=2,
-        seed=lambda wildcards: training_seed_list[int(wildcards.test_rep)][int(wildcards.training_rep)],
+        sim=lambda wildcards: get_simulation_params(wildcards, "training"),
     resources:
         mem_gb=16,
     script:
@@ -50,28 +40,18 @@ rule simulate_training_data:
 
 rule simulate_test_data:
     input:
-        demes="config/ArchIE_3D19.yaml",
+        demes="config/{demog_model}.yaml",
     output:
-        ts=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.ts"),
-        vcf=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.vcf"),
-        bed_phased=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.phased.bed"),
-        bed_unphased=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.unphased.bed"),
-        ref_list=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.ref.list"),
-        tgt_list=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.tgt.list"),
-        src_list=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.src.list"),
-        seed_file=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.seedmsprime"),
+        ts=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.ts"),
+        vcf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.vcf"),
+        bed_phased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.phased.bed"),
+        bed_unphased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.unphased.bed"),
+        ref_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.ref.list"),
+        tgt_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.tgt.list"),
+        src_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.src.list"),
+        seed_file=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.seedmsprime"),
     params:
-        n_ref=50,
-        n_tgt=50,
-        n_src=0,
-        length_bp=200_000_000,
-        mu=1.2e-8,
-        rho=1e-8,
-        ref_id="Reference",
-        tgt_id="Target",
-        src_id="Source",
-        ploidy=2,
-        seed=lambda wildcards: test_seed_list[int(wildcards.test_rep)],
+        sim=lambda wildcards: get_simulation_params(wildcards, "test"),
     resources:
         time=360, mem_gb=16,
     script:
@@ -82,7 +62,7 @@ rule extract_training_biallelic_snps:
     input:
         vcf=rules.simulate_training_data.output.vcf,
     output:
-        vcf=temp("results/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.biallelic.snps.vcf.gz"),
+        vcf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.biallelic.snps.vcf.gz"),
     shell:
         """
         bcftools view {input.vcf} -v snps -m 2 -M 2 -g ^miss | bgzip -c > {output.vcf}
@@ -94,7 +74,7 @@ rule extract_test_biallelic_snps:
     input:
         vcf=rules.simulate_test_data.output.vcf,
     output:
-        vcf=temp("results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.biallelic.snps.vcf.gz"),
+        vcf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.biallelic.snps.vcf.gz"),
     shell:
         """
         bcftools view {input.vcf} -v snps -m 2 -M 2 -g ^miss | bgzip -c > {output.vcf}
@@ -108,7 +88,7 @@ rule calc_training_sstar_score:
         ref_list=rules.simulate_training_data.output.ref_list,
         tgt_list=rules.simulate_training_data.output.tgt_list,
     output:
-        score=temp("results/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{training_rep}.scores.tsv"),
+        score=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{training_rep}.scores.tsv"),
     params:
         win_len=50000,
         win_step=50000,
@@ -134,12 +114,12 @@ rule calc_training_sstar_score:
 rule merge_training_sstar_score:
     input:
         scores=expand(
-            "results/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{training_rep}.scores.tsv",
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{training_rep}.scores.tsv",
             training_rep=range(TRAINING_REP),
             allow_missing=True,
         ),
     output:
-        scores="results/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.training.scores.tsv",
+        scores="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.training.scores.tsv",
     shell:
         """
         awk 'FNR==1 && NR!=1 {{next}} {{print}}' {input.scores} > {output.scores}

--- a/workflow/rules/sstar.smk
+++ b/workflow/rules/sstar.smk
@@ -29,7 +29,7 @@ rule sstar_score:
         ref_list=rules.simulate_test_data.output.ref_list,
         tgt_list=rules.simulate_test_data.output.tgt_list,
     output:
-        scores="results/simulation/test/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.scores.tsv",
+        scores="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.scores.tsv",
     params:
         win_len=50000,
         win_step=50000,
@@ -54,12 +54,15 @@ rule sstar_score:
 
 rule sstar_quantile:
     input:
-        model="config/ArchIE_3D19_wo_introgression.yaml",
+        model="config/{demog_model}_wo_introgression.yaml",
     output:
-        quantile="results/sstar/{phase_state}/rep_{test_rep}/quantile.summary.txt",
+        quantile="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/quantile.summary.txt",
     params:
         ms_dir="resources/msdir",
-        output_dir="results/sstar/{phase_state}/rep_{test_rep}",
+        output_dir="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}",
+        pop_config=get_pop_config,
+        sample_size=get_sample_size,
+        length_bp=LENGTH_BPS["training"],
     resources:
         time=360, mem_gb=128, cpus=32,
     conda:
@@ -70,15 +73,15 @@ rule sstar_quantile:
           --model {input.model} \
           --ms-dir {params.ms_dir} \
           --N0 1000 \
-          --nsamp 200 \
+          --nsamp {params.sample_size[total]} \
           --nreps 10000 \
-          --ref-index 3 \
-          --ref-size 100 \
-          --tgt-index 4 \
-          --tgt-size 100 \
-          --mut-rate 1.2e-8 \
-          --rec-rate 1.0e-8 \
-          --seq-len 50000 \
+          --ref-index {params.pop_config.ref_index} \
+          --ref-size {params.sample_size[ref]} \
+          --tgt-index {params.pop_config.tgt_index} \
+          --tgt-size {params.sample_size[tgt]} \
+          --mut-rate {params.pop_config.mut_rate} \
+          --rec-rate {params.pop_config.rec_rate} \
+          --seq-len {params.length_bp} \
           --snp-num-range 50 350 5 \
           --output-dir {params.output_dir} \
           --thread {resources.cpus} \
@@ -90,9 +93,10 @@ rule sstar_threshold:
         scores=rules.sstar_score.output.scores,
         quantile=rules.sstar_quantile.output.quantile,
     output:
-        preds="results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.preds.tsv",
+        preds="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.preds.tsv",
     params:
         phased_flag=lambda wildcards: "--phased" if wildcards.phase_state == "phased" else "",
+        pop_config=get_pop_config,
     conda:
         "../envs/sstar.yaml",
     shell:
@@ -100,7 +104,7 @@ rule sstar_threshold:
         sstar threshold \
           --score {input.scores} \
           --sim-data {input.quantile} \
-          --recomb-rate 1.0e-8 \
+          --recomb-rate {params.pop_config.rec_rate} \
           --quantile {wildcards.quantile} \
           --output {output.preds} \
           --k 8 \
@@ -112,21 +116,19 @@ rule get_sstar_inferred_tracts:
     input:
         preds=rules.sstar_threshold.output.preds,
     output:
-        bed="results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
-    params:
-        phased=lambda wildcards: wildcards.phase_state == "phased",
+        bed="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
     shell:
         r"""
-        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$6 {{print $1,$2,$3,$4}}' {input.preds} | awk 'BEGIN{{FS=OFS="\t"}} {{if ("{params.phased}"=="True") gsub(/hap/, "", $4); print}}' > {output.bed}
+        awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$6 {{print $1,$2,$3,$4}}' {input.preds} | awk 'BEGIN{{FS=OFS="\t"}} {{if ("{wildcards.phase_state}"=="phased") gsub(/hap/, "", $4); print}}' > {output.bed}
         """
 
 
 rule evaluate_sstar:
     input:
-        true_tracts="results/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.{phase_state}.bed",
+        true_tracts="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.true.tracts.{phase_state}.bed",
         inferred_tracts=rules.get_sstar_inferred_tracts.output.bed,
     output:
-        tsv="results/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+        tsv="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
     params:
         length_bp=200_000_000,
         cutoff="{quantile}",

--- a/workflow/scripts/msprime_simulation.py
+++ b/workflow/scripts/msprime_simulation.py
@@ -273,20 +273,20 @@ def get_true_tracts(
 
 
 with open(snakemake.output.seed_file, "w") as o:
-    o.write(f"{snakemake.params.seed}\n")
+    o.write(f"{snakemake.params.sim['seed']}\n")
 
 ts = simulate(
     demog=snakemake.input.demes,
-    nref=int(snakemake.params.n_ref),
-    ntgt=int(snakemake.params.n_tgt),
-    nsrc=int(snakemake.params.n_src),
-    ref_id=snakemake.params.ref_id,
-    tgt_id=snakemake.params.tgt_id,
-    src_id=snakemake.params.src_id,
-    seq_len=int(snakemake.params.length_bp),
-    mut_rate=float(snakemake.params.mu),
-    rec_rate=float(snakemake.params.rho),
-    seed=int(snakemake.params.seed),
+    nref=int(snakemake.wildcards.n_ref),
+    ntgt=int(snakemake.wildcards.n_tgt),
+    nsrc=int(snakemake.wildcards.n_src),
+    ref_id=snakemake.params.sim["ref_id"],
+    tgt_id=snakemake.params.sim["tgt_id"],
+    src_id=snakemake.params.sim["src_id"],
+    seq_len=int(snakemake.params.sim["length_bp"]),
+    mut_rate=float(snakemake.params.sim["mu"]),
+    rec_rate=float(snakemake.params.sim["rho"]),
+    seed=int(snakemake.params.sim["seed"]),
 )
 
 ts.dump(snakemake.output.ts)
@@ -296,9 +296,9 @@ with open(snakemake.output.vcf, "w") as o:
     ts.write_vcf(o, allow_position_zero=True)
 
 create_sample_lists(
-    nref=int(snakemake.params.n_ref),
-    ntgt=int(snakemake.params.n_tgt),
-    nsrc=int(snakemake.params.n_src),
+    nref=int(snakemake.wildcards.n_ref),
+    ntgt=int(snakemake.wildcards.n_tgt),
+    nsrc=int(snakemake.wildcards.n_src),
     ref_list=snakemake.output.ref_list,
     tgt_list=snakemake.output.tgt_list,
     src_list=snakemake.output.src_list,
@@ -312,10 +312,10 @@ true_tract_output = {
 for phased_status in ["phased", "unphased"]:
     true_tracts = get_true_tracts(
         ts=ts,
-        tgt_id=snakemake.params.tgt_id,
-        src_id=snakemake.params.src_id,
+        tgt_id=snakemake.params.sim["tgt_id"],
+        src_id=snakemake.params.sim["src_id"],
         is_phased=phased_status == "phased",
-        ploidy=int(snakemake.params.ploidy),
+        ploidy=int(snakemake.params.sim["ploidy"]),
     )
 
     true_tracts = pr.from_string(true_tracts).merge(by="Sample")


### PR DESCRIPTION
### Motivation
- Make the workflow support multiple demographic models and configurable sample sizes and lengths rather than hard-coded ArchIE/Reference values.
- Centralize population-specific parameters (mutation/rec rates and population IDs) and seed selection to avoid duplication across rules.
- Ensure output paths include demography and sampling metadata so results are organized by model and sample configuration.

### Description
- Added `DEMOGRAPHIC_MODELS`, `N_REFS`, `N_TGTS`, `N_SRCS`, `LENGTH_BPS`, `PopConfig` and `POP_CONFIGS` to the top-level `Snakefile` and replaced hard-coded constants with these variables and wildcards like `{demog_model}`, `nref_{n_ref}`, `ntgt_{n_tgt}`, and `nsrc_{n_src}` in result paths.
- Introduced `workflow/rules/common.smk` with `get_pop_config` and `get_simulation_params` helper functions and wired `simulate_*` rules to call `get_simulation_params` for training and test splits via `params.sim`.
- Updated `rules/simulation.smk`, `rules/sstar.smk`, and `rules/qr.smk` to use the new wildcards in `input`/`output` paths and to reference `params.sim` or `wildcards` where appropriate (including replacing earlier `params.phased` usage with direct `wildcards.phase_state` checks inside shell/awk commands).
- Modified `scripts/msprime_simulation.py` to consume `snakemake.params.sim` for simulation parameters and to use `snakemake.wildcards` for `n_ref`/`n_tgt`/`n_src`; also adjusted writing of the seed file to use the new `sim['seed']` entry.
- Included the new `common.smk` from the top-level `Snakefile` to expose helper functions across rules.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ac2fb6c4832cb77d99cc9c1dd377)