### PR TITLE
Use biallelic VCFs for S* scoring

### DIFF
--- a/workflow/rules/simulation.smk
+++ b/workflow/rules/simulation.smk
@@ -84,7 +84,7 @@ rule extract_test_biallelic_snps:
 
 rule calc_training_sstar_score:
     input:
-        vcf=rules.simulate_training_data.output.vcf,
+        vcf=rules.extract_training_biallelic_snps.output.vcf,
         ref_list=rules.simulate_training_data.output.ref_list,
         tgt_list=rules.simulate_training_data.output.tgt_list,
     output:

--- a/workflow/rules/sstar.smk
+++ b/workflow/rules/sstar.smk
@@ -25,7 +25,7 @@ ruleorder: evaluate_sstar > evaluate_qr
 
 rule sstar_score:
     input:
-        vcf=rules.simulate_test_data.output.vcf,
+        vcf=rules.extract_test_biallelic_snps.output.vcf,
         ref_list=rules.simulate_test_data.output.ref_list,
         tgt_list=rules.simulate_test_data.output.tgt_list,
     output:


### PR DESCRIPTION
### Motivation
- Ensure the S* scoring step operates on cleaned biallelic SNP VCFs (no multiallelic or missing-genotype sites) rather than raw simulated VCFs to make scores consistent with downstream analysis.

### Description
- Updated the test-set S* scoring rule in `workflow/rules/sstar.smk` to take `rules.extract_test_biallelic_snps.output.vcf` as the `--vcf` input instead of the raw simulated VCF.
- Updated the training-set S* scoring rule in `workflow/rules/simulation.smk` (`calc_training_sstar_score`) to take `rules.extract_training_biallelic_snps.output.vcf` as the `--vcf` input instead of the raw simulated VCF.
- The change is limited to replacing the `vcf=` inputs in the two rules so that the existing `extract_*_biallelic_snps` rules are used.

### Testing
- Ran `git diff --check` which reported no whitespace or diff issues and passed.
- Attempted `snakemake --version` to validate the runtime, but it failed because `snakemake` is not installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf29b3aa083248cc023245278ece2)