### PR TITLE
Seed NumPy generator deterministically

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -82,8 +82,7 @@ POP_CONFIGS = {
     ),
 }
 
-np.random.seed(3821)
-rng = np.random.default_rng()
+rng = np.random.default_rng(3821)
 all_seeds = rng.choice(
     2**31 - 1,
     size=TEST_REP * TRAINING_REP + TEST_REP,


### PR DESCRIPTION
### Motivation
- Ensure reproducible RNG state by using a seeded instance of NumPy's `Generator` instead of relying on `np.random.seed(...)` plus an unseeded `default_rng()`.

### Description
- In `workflow/Snakefile` replace `np.random.seed(3821)` and the subsequent unseeded `np.random.default_rng()` with `rng = np.random.default_rng(3821)` so `all_seeds` are produced deterministically.

### Testing
- Ran `git diff --check` which reported no issues, and attempted a Python seed-generation validation which could not run because the environment does not have `numpy` installed (so the assertions were not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf789a2808324910bc76fd33996a5)