### PR TITLE
Handle empty segment evaluations

### DIFF
--- a/workflow/scripts/segment_based_evaluation.py
+++ b/workflow/scripts/segment_based_evaluation.py
@@ -170,16 +170,23 @@ def evaluate(
     sum_nfalse_positives = sum_ninferred_tracts - sum_ntrue_positives
     sum_nfalse_negatives = sum_ntrue_tracts - sum_ntrue_positives
 
+    if sample_size == 0:
+        per_sample_metrics = [np.nan] * 6
+    else:
+        per_sample_metrics = [
+            sum_ntrue_tracts / sample_size,
+            sum_ninferred_tracts / sample_size,
+            sum_ntrue_positives / sample_size,
+            sum_nfalse_positives / sample_size,
+            sum_ntrue_negatives / sample_size,
+            sum_nfalse_negatives / sample_size,
+        ]
+
     res.loc[len(res.index)] = [
         cutoff,
         total_precision,
         total_recall,
-        sum_ntrue_tracts / sample_size,
-        sum_ninferred_tracts / sample_size,
-        sum_ntrue_positives / sample_size,
-        sum_nfalse_positives / sample_size,
-        sum_ntrue_negatives / sample_size,
-        sum_nfalse_negatives / sample_size,
+        *per_sample_metrics,
     ]
 
     res.fillna("NaN").to_csv(output, sep="\t", index=False)


### PR DESCRIPTION
### Motivation
- Prevent a divide-by-zero when both true and inferred tract files are empty by guarding per-sample averages computed from `sample_size`.

### Description
- In `workflow/scripts/segment_based_evaluation.py` add a branch that sets per-sample metrics to `NaN` when `sample_size == 0` and otherwise computes the same six averages as before.
- Preserve existing behavior for total `precision`/`recall` coming from `calc_pr` while changing the row construction to use a `per_sample_metrics` list unpacked into the result row.

### Testing
- Ran `python -m py_compile workflow/scripts/segment_based_evaluation.py` which succeeded.
- Attempted to execute the script with empty input files to validate the empty-case output but the runtime check failed due to the environment missing `numpy` (import error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf8578d288324adbee82a3d2a73b8)