### PR TITLE
Use explicit Snakemake input filenames

### DIFF
--- a/workflow/rules/performance.smk
+++ b/workflow/rules/performance.smk
@@ -56,13 +56,13 @@ rule collect_sstar_performance_across_cutoffs:
 rule collect_performance_across_replicates:
     input:
         qr=expand(
-            rules.collect_qr_performance_across_cutoffs.output.perf,
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.pred.perf.tsv",
             qr_model=["quantile", "qrf"],
             test_rep=range(TEST_REP),
             allow_missing=True,
         ),
         sstar=expand(
-            rules.collect_sstar_performance_across_cutoffs.output.perf,
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{version}/{phase_state}/rep_{test_rep}/{version}.pred.perf.tsv",
             version=["quantile", "qrf", "sstar", "sstar2"],
             test_rep=range(TEST_REP),
             allow_missing=True,
@@ -80,7 +80,7 @@ rule collect_performance_across_replicates:
 rule plot_pr_curve:
     input:
         perf=expand(
-            rules.collect_performance_across_replicates.output.perf,
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/performance/{phase_state}/combined.pred.perf.tsv",
             demog_model=DEMOGRAPHIC_MODELS,
             phase_state=PHASE_STATES,
             allow_missing=True,

--- a/workflow/rules/qr.smk
+++ b/workflow/rules/qr.smk
@@ -20,8 +20,8 @@
 
 #rule run_qr:
 #    input:
-#        training_data=rules.merge_training_sstar_score.output.scores,
-#        test_data=rules.sstar_score.output.scores,
+#        training_data="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.training.scores.tsv",
+#        test_data="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.scores.tsv",
 #    output:
 #        pred=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{phase_state}.q_{quantile}.rep_{test_rep}.pred.tsv"),
 #    resources:
@@ -34,7 +34,7 @@
 
 #rule get_qr_inferred_tracts:
 #    input:
-#        preds=rules.run_qr.output.pred,
+#        preds="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{phase_state}.q_{quantile}.rep_{test_rep}.pred.tsv",
 #    output:
 #        bed="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
 #    shell:

--- a/workflow/rules/simulation.smk
+++ b/workflow/rules/simulation.smk
@@ -60,7 +60,7 @@ rule simulate_test_data:
 
 rule extract_training_biallelic_snps:
     input:
-        vcf=rules.simulate_training_data.output.vcf,
+        vcf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.vcf",
     output:
         vcf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.biallelic.snps.vcf.gz"),
         idx=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.biallelic.snps.vcf.gz.tbi"),
@@ -73,7 +73,7 @@ rule extract_training_biallelic_snps:
 
 rule extract_test_biallelic_snps:
     input:
-        vcf=rules.simulate_test_data.output.vcf,
+        vcf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.vcf",
     output:
         vcf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.biallelic.snps.vcf.gz",
         idx="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.biallelic.snps.vcf.gz.tbi",
@@ -86,9 +86,9 @@ rule extract_test_biallelic_snps:
 
 rule calc_training_sstar_score:
     input:
-        vcf=rules.extract_training_biallelic_snps.output.vcf,
-        ref_list=rules.simulate_training_data.output.ref_list,
-        tgt_list=rules.simulate_training_data.output.tgt_list,
+        vcf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.biallelic.snps.vcf.gz",
+        ref_list="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ref.list",
+        tgt_list="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.tgt.list",
     output:
         score=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/sstar.{phase_state}.rep_{training_rep}.scores.tsv"),
     params:

--- a/workflow/rules/sstar.smk
+++ b/workflow/rules/sstar.smk
@@ -25,9 +25,9 @@ ruleorder: evaluate_sstar > evaluate_qr
 
 #rule sstar_score:
 #    input:
-#        vcf=rules.extract_test_biallelic_snps.output.vcf,
-#        ref_list=rules.simulate_test_data.output.ref_list,
-#        tgt_list=rules.simulate_test_data.output.tgt_list,
+#        vcf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.biallelic.snps.vcf.gz",
+#        ref_list="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.ref.list",
+#        tgt_list="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.tgt.list",
 #    output:
 #        scores="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.scores.tsv",
 #    params:
@@ -89,8 +89,8 @@ ruleorder: evaluate_sstar > evaluate_qr
 
 #rule sstar_threshold:
 #    input:
-#        scores=rules.sstar_score.output.scores,
-#        quantile=rules.sstar_quantile.output.quantile,
+#        scores="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.scores.tsv",
+#        quantile="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/quantile.summary.txt",
 #    output:
 #        pred=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.pred.tsv"),
 #    params:
@@ -111,7 +111,7 @@ ruleorder: evaluate_sstar > evaluate_qr
 
 #rule get_sstar_inferred_tracts:
 #    input:
-#        pred=rules.sstar_threshold.output.pred,
+#        pred="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.pred.tsv",
 #    output:
 #        bed="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
 #    shell:

--- a/workflow/rules/sstar2.smk
+++ b/workflow/rules/sstar2.smk
@@ -21,7 +21,7 @@
 #rule render_sstar2_config_template:
 #    input:
 #        template="config/sstar2.config.template.yaml",
-#        vcf=rules.extract_test_biallelic_snps.output.vcf,
+#        vcf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.biallelic.snps.vcf.gz",
 #    output:
 #        config="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.config.yaml",
 #    params:
@@ -33,7 +33,7 @@
 #rule run_sstar2_train:
 #    input:
 #        demes="config/demog_models/{demog_model}_wo_introgression.yaml",
-#        config=rules.render_sstar2_config_template.output.config,
+#        config="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.config.yaml",
 #    output:
 #        model="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.onnx",
 #    resources:
@@ -48,8 +48,8 @@
 
 #rule run_sstar2_infer:
 #    input:
-#        model=rules.run_sstar2_train.output.model,
-#        config=rules.render_sstar2_config_template.output.config,
+#        model="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.onnx",
+#        config="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.config.yaml",
 #    output:
 #        feat=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.processed.features.tsv"),
 #        pred=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.pred.tsv"),


### PR DESCRIPTION
### Motivation
- Replace indirect `rules.<rule>.output.<name>` references with explicit filename patterns to make rule inputs self-contained and easier to inspect.
- Improve readability and avoid cross-rule object lookups inside `expand(...)` calls and commented examples.
- Preserve existing workflow semantics and output filenames while making dependencies explicit.

### Description
- Replaced indirect `rules.collect_qr_performance_across_cutoffs.output.perf`, `rules.collect_sstar_performance_across_cutoffs.output.perf`, and `rules.collect_performance_across_replicates.output.perf` references with explicit paths in `workflow/rules/performance.smk` for the `collect_performance_across_replicates` and `plot_pr_curve` inputs.
- Replaced `rules.simulate_training_data.output.vcf`, `rules.simulate_test_data.output.vcf`, and simulation-derived list references with explicit result file patterns in `workflow/rules/simulation.smk` for `extract_*` and `calc_training_sstar_score` inputs.
- Updated commented-out example rules in `workflow/rules/qr.smk`, `workflow/rules/sstar.smk`, and `workflow/rules/sstar2.smk` so their `input` sections use the same explicit filename patterns instead of `rules.*.output.*` references.
- Made only syntactic changes to input expressions; preserved existing output filenames, formats, and workflow semantics.

### Testing
- Ran `rg -n "rules\.[A-Za-z0-9_]+\.output(\.[A-Za-z0-9_]+)?" . || true` to search for remaining indirect references, which returned no matches (success).
- Executed a Python check that asserts the updated files no longer contain `rules.*.output` references, which completed successfully with the message `No rules.*.output references remain in checked workflow rule files`.
- Attempted to run `snakemake --version && snakemake -n --snakefile workflow/Snakefile --cores 1`, but `snakemake` is not installed in the environment so the dry-run could not be executed (skipped due to missing dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d85cbab8832cb5155092f5ae62d5)