### PR TITLE
Remove deprecated sample-length performance headers

### DIFF
--- a/workflow/rules/performance.smk
+++ b/workflow/rules/performance.smk
@@ -33,7 +33,7 @@ rule collect_qr_performance_across_cutoffs:
     shell:
         r"""
         cat {input.perf} | grep -v Cutoff | awk -v rep={wildcards.test_rep} -v method="{wildcards.qr_model}" -v nref={wildcards.n_ref} -v ntgt={wildcards.n_tgt} '{{print rep"\t"method"\t"nref"\t"ntgt"\t"$0}}' > {output.perf}
-        sed -i '1iReplicate\tMethod\tN_ref\tN_tgt\tCutoff\tPrecision\tRecall\tL_TT_sample\tL_IT_sample\tL_TP_sample\tL_FP_sample\tL_TN_sample\tL_FN_sample' {output.perf}
+        sed -i '1iReplicate\tMethod\tN_ref\tN_tgt\tCutoff\tPrecision\tRecall' {output.perf}
         """
 
 
@@ -49,7 +49,7 @@ rule collect_sstar_performance_across_cutoffs:
     shell:
         r"""
         cat {input.perf} | grep -v Cutoff | awk -v rep={wildcards.test_rep} -v version={wildcards.version} -v nref={wildcards.n_ref} -v ntgt={wildcards.n_tgt} '{{print rep"\t"version"\t"nref"\t"ntgt"\t"$0}}' > {output.perf}
-        sed -i '1iReplicate\tMethod\tN_ref\tN_tgt\tCutoff\tPrecision\tRecall\tL_TT_sample\tL_IT_sample\tL_TP_sample\tL_FP_sample\tL_TN_sample\tL_FN_sample' {output.perf}
+        sed -i '1iReplicate\tMethod\tN_ref\tN_tgt\tCutoff\tPrecision\tRecall' {output.perf}
         """
 
 


### PR DESCRIPTION
### Motivation
- The per-sample length metrics (`L_TT_sample`, `L_IT_sample`, `L_TP_sample`, `L_FP_sample`, `L_TN_sample`, `L_FN_sample`) were removed from `segment_base_evaluation`, so the performance aggregation headers must not reference these deprecated columns.

### Description
- Update `workflow/rules/performance.smk` to remove the deprecated sample-length columns from the header inserted by the `sed -i` calls in `collect_qr_performance_across_cutoffs` and `collect_sstar_performance_across_cutoffs`, leaving the header as `Replicate\tMethod\tN_ref\tN_tgt\tCutoff\tPrecision\tRecall`.

### Testing
- Ran `rg -n "L_TT_sample|L_IT_sample|L_TP_sample|L_FP_sample|L_TN_sample|L_FN_sample" . || true` to verify occurrences were removed (no matches reported) and inspected the modified file with `git status --short`, both indicating the intended change was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1951d64590832c88874974441ae2d2)