### PR TITLE
Constrain `demog_model` wildcard to `SINGLE_SOURCE_MODELS_REGEX` in QR, sstar, sstar2 and performance rules

### DIFF
--- a/workflow/rules/performance.smk
+++ b/workflow/rules/performance.smk
@@ -87,7 +87,7 @@ rule plot_pr_curve:
     input:
         perf=expand(
             "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/performance/{phase_state}/combined.pred.perf.tsv",
-            demog_model=DEMOGRAPHIC_MODELS,
+            demog_model=SINGLE_SOURCE_MODELS,
             phase_state=PHASE_STATES,
             allow_missing=True,
         ),

--- a/workflow/rules/performance.smk
+++ b/workflow/rules/performance.smk
@@ -30,6 +30,8 @@ rule collect_qr_performance_across_cutoffs:
         ),
     output:
         perf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.pred.perf.tsv"),
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     shell:
         r"""
         cat {input.perf} | grep -v Cutoff | awk -v rep={wildcards.test_rep} -v method="{wildcards.qr_model}" -v nref={wildcards.n_ref} -v ntgt={wildcards.n_tgt} '{{print rep"\t"method"\t"nref"\t"ntgt"\t"$0}}' > {output.perf}
@@ -46,6 +48,8 @@ rule collect_sstar_performance_across_cutoffs:
         ),
     output:
         perf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{version}/{phase_state}/rep_{test_rep}/{version}.pred.perf.tsv"),
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     shell:
         r"""
         cat {input.perf} | grep -v Cutoff | awk -v rep={wildcards.test_rep} -v version={wildcards.version} -v nref={wildcards.n_ref} -v ntgt={wildcards.n_tgt} '{{print rep"\t"version"\t"nref"\t"ntgt"\t"$0}}' > {output.perf}
@@ -69,6 +73,8 @@ rule collect_performance_across_replicates:
         ),
     output:
         perf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/performance/{phase_state}/combined.pred.perf.tsv",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     shell:
         r"""
         head -n 1 {input.qr[0]} > {output.perf}

--- a/workflow/rules/qr.smk
+++ b/workflow/rules/qr.smk
@@ -25,6 +25,7 @@ rule run_qr:
     output:
         pred=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{phase_state}.q_{quantile}.rep_{test_rep}.pred.tsv"),
     wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
         qr_model = "qrf|quantile",
     resources:
         time=720, mem_mb=16000,
@@ -40,6 +41,7 @@ rule get_qr_inferred_tracts:
     output:
         bed="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
     wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
         qr_model = "qrf|quantile",
     shell:
         r"""
@@ -54,6 +56,7 @@ rule evaluate_qr:
     output:
         tsv="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/{qr_model}/{phase_state}/rep_{test_rep}/{qr_model}.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
     wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
         qr_model = "qrf|quantile",
     params:
         length_bp=200_000_000,

--- a/workflow/rules/sstar.smk
+++ b/workflow/rules/sstar.smk
@@ -25,6 +25,8 @@ rule sstar_score:
         tgt_list="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.tgt.list",
     output:
         scores="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/sstar.{phase_state}.rep_{test_rep}.scores.tsv",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     params:
         pop_config=get_pop_config,
         win_step=10000,
@@ -52,6 +54,8 @@ rule sstar_quantile:
         model="config/demog_models/{demog_model}_wo_introgression.yaml",
     output:
         quantile="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/quantile.summary.txt",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     params:
         ms_dir="resources/msdir",
         output_dir="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}",
@@ -88,6 +92,8 @@ rule sstar_threshold:
         quantile="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/quantile.summary.txt",
     output:
         pred=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.pred.tsv"),
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     params:
        phased_flag=lambda wildcards: "--phased" if wildcards.phase_state == "phased" else "",
     conda:
@@ -109,6 +115,8 @@ rule get_sstar_inferred_tracts:
         pred="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.pred.tsv",
     output:
         bed="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     shell:
         r"""
         awk 'BEGIN{{FS=OFS="\t"}} NR==1{{next}} $5>$6 {{print $1,$2,$3,$4}}' {input.pred} | awk 'BEGIN{{FS=OFS="\t"}} {{if ("{wildcards.phase_state}"=="phased") gsub(/hap/, "", $4); print}}' > {output.bed}
@@ -121,6 +129,8 @@ rule evaluate_sstar:
         inferred_tracts="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
     output:
         tsv="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar/{phase_state}/rep_{test_rep}/sstar.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     params:
         length_bp=TEST_LENGTH_BP,
         cutoff="{quantile}",

--- a/workflow/rules/sstar2.smk
+++ b/workflow/rules/sstar2.smk
@@ -24,6 +24,8 @@ rule render_sstar2_config_template:
         vcf="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.biallelic.snps.vcf.gz",
     output:
         config="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.config.yaml",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     params:
         sstar2=get_sstar2_config_params,
     template_engine:
@@ -36,6 +38,8 @@ rule run_sstar2_train:
         config="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.config.yaml",
     output:
         model="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.onnx",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     resources:
         mem_mb=64000, cpus=32, time=360,
     conda:
@@ -54,6 +58,8 @@ rule run_sstar2_infer:
         feat=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.processed.features.tsv"),
         pred=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.pred.tsv"),
         tracts="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     resources:
         mem_mb=64000, cpus=32,
     conda:
@@ -70,6 +76,8 @@ rule evaluate_sstar2:
         inferred_tracts="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/q_{quantile}/sstar2.q_{quantile}.rep_{test_rep}.inferred.tracts.bed",
     output:
         tsv="results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/sstar2/{phase_state}/rep_{test_rep}/sstar2.{phase_state}.q_{quantile}.rep_{test_rep}.perf.tsv",
+    wildcard_constraints:
+        demog_model=SINGLE_SOURCE_MODELS_REGEX,
     params:
         length_bp=TEST_LENGTH_BP,
         cutoff="{quantile}",


### PR DESCRIPTION
### Motivation
- Ensure rules only match single-source demographic models by restricting the `demog_model` wildcard to `SINGLE_SOURCE_MODELS_REGEX`.
- Prevent unintended wildcard expansion for multi-source models and improve workflow determinism.
- Reduce spurious rule matches and make the pipeline behavior clearer for model-specific rules.

### Description
- Added `wildcard_constraints: demog_model=SINGLE_SOURCE_MODELS_REGEX` to performance rules in `workflow/rules/performance.smk` (`collect_qr_performance_across_cutoffs`, `collect_sstar_performance_across_cutoffs`, `collect_performance_across_replicates`).
- Added the same wildcard constraint to QR rules in `workflow/rules/qr.smk` (`run_qr`, `get_qr_inferred_tracts`, `evaluate_qr`).
- Added the wildcard constraint to S*STAR rules in `workflow/rules/sstar.smk` (`sstar_score`, `sstar_quantile`, `sstar_threshold`, `get_sstar_inferred_tracts`, `evaluate_sstar`).
- Added the wildcard constraint to S*STAR2 rules in `workflow/rules/sstar2.smk` (`render_sstar2_config_template`, `run_sstar2_train`, `run_sstar2_infer`, `evaluate_sstar2`).

### Testing
- Ran `snakemake --lint` to validate the workflow syntax and rule constraints, which completed successfully.
- Performed a Snakemake dry-run with `snakemake -n` to verify rule matching behavior, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ea5bdbdc832cb30402e58b8ceffe)