### PR TITLE
Remove two-source training rule and add aggregate two-source test rule

### DIFF
--- a/workflow/rules/simulation.smk
+++ b/workflow/rules/simulation.smk
@@ -94,11 +94,14 @@ rule simulate_two_source_test_data:
 rule two_source_test_simulation:
     input:
         expand(
-            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_0/simulation.rep_0.src1.true.tracts.phased.bed",
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_{test_rep}/simulation.rep_{test_rep}.{tract_source}.true.tracts.{phase_state}.bed",
             demog_model=TWO_SOURCE_MODELS,
             n_ref=N_REFS,
             n_tgt=N_TGTS,
             n_src=N_SRCS,
+            test_rep=range(TEST_REP),
+            tract_source=["src1", "src2"],
+            phase_state=PHASE_STATES,
         )
 
 

--- a/workflow/rules/simulation.smk
+++ b/workflow/rules/simulation.smk
@@ -41,31 +41,6 @@ rule simulate_single_source_training_data:
         "../scripts/msprime_simulation.py"
 
 
-rule simulate_two_source_training_data:
-    input:
-        demes="config/demog_models/{demog_model}_wo_introgression.yaml",
-    output:
-        ts=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ts"),
-        vcf=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.vcf"),
-        ref_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.ref.list"),
-        tgt_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.tgt.list"),
-        src_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src.list"),
-        src2_list=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src2.list"),
-        seed_file=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.seedmsprime"),
-        bed_src1_phased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src1.true.tracts.phased.bed"),
-        bed_src1_unphased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src1.true.tracts.unphased.bed"),
-        bed_src2_phased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src2.true.tracts.phased.bed"),
-        bed_src2_unphased=temp("results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/training/rep_{test_rep}/simulation.rep_{training_rep}.src2.true.tracts.unphased.bed"),
-    params:
-        sim=lambda wildcards: get_simulation_params(wildcards, "training"),
-    wildcard_constraints:
-        demog_model=TWO_SOURCE_MODELS_REGEX,
-    resources:
-        mem_mb=16000,
-    script:
-        "../scripts/msprime_simulation.py"
-
-
 rule simulate_single_source_test_data:
     input:
         demes="config/demog_models/{demog_model}.yaml",
@@ -114,6 +89,17 @@ rule simulate_two_source_test_data:
         mem_mb=16000,
     script:
         "../scripts/msprime_simulation.py"
+
+
+rule two_source_test_simulation:
+    input:
+        expand(
+            "results/{demog_model}/nref_{n_ref}/ntgt_{n_tgt}/nsrc_{n_src}/simulation/test/rep_0/simulation.rep_0.src1.true.tracts.phased.bed",
+            demog_model=TWO_SOURCE_MODELS,
+            n_ref=N_REFS,
+            n_tgt=N_TGTS,
+            n_src=N_SRCS,
+        )
 
 
 rule extract_training_biallelic_snps:


### PR DESCRIPTION
### Motivation
- Remove an unused or redundant two-source training simulation rule and introduce an aggregate rule to ensure presence of two-source test-phase tract files across parameter combinations.

### Description
- Deleted the `simulate_two_source_training_data` Snakemake rule that generated training-phase two-source simulation outputs.
- Added a new rule `two_source_test_simulation` that expands expected `src1.true.tracts.phased.bed` test outputs for all `TWO_SOURCE_MODELS` and parameter sets `N_REFS`, `N_TGTS`, and `N_SRCS` using `expand`.
- Left single-source training/test and two-source test simulation rules intact and unchanged aside from the above removal and addition.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36f24e1b18832c90f815d07ddf86f5)