### PR TITLE
Fix true tract extraction and output handling in msprime_simulation.py

### DIFF
--- a/workflow/scripts/msprime_simulation.py
+++ b/workflow/scripts/msprime_simulation.py
@@ -305,9 +305,15 @@ def get_true_tracts(
     else:
         src_ids = tuple(src_id)
 
-    src_pops = [p.id for p in ts.populations() if p.metadata["name"] in src_ids]
-    if not src_pops:
-        raise ValueError(f"Population {src_id} is not found.")
+    src_pop_by_name = {
+        p.metadata["name"]: p.id
+        for p in ts.populations()
+        if p.metadata["name"] in src_ids
+    }
+    missing_src_ids = set(src_ids) - set(src_pop_by_name)
+    if missing_src_ids:
+        raise ValueError(f"Population(s) {sorted(missing_src_ids)} are not found.")
+    src_pops = list(src_pop_by_name.values())
 
     try:
         tgt_pop = [p.id for p in ts.populations() if p.metadata["name"] == tgt_id][0]

--- a/workflow/scripts/msprime_simulation.py
+++ b/workflow/scripts/msprime_simulation.py
@@ -260,7 +260,7 @@ def get_true_tracts(
     During tree traversal, an active migration set and tracked target samples are
     used to avoid scanning every tree and every target sample for each migration.
 
-    The output is a tab-delimited string with a header line:
+    The output is written as a tab-delimited BED-like file with columns:
 
         Chromosome  Start  End  Sample
 
@@ -276,9 +276,13 @@ def get_true_tracts(
     tgt_id : str
         Name of the target population, as stored in
         `ts.populations().metadata["name"]`.
-    src_id : str
-        Name of the source population, as stored in
-        `ts.populations().metadata["name"]`.
+    src_id : str or tuple[str, ...] or list[str]
+        Name or names of source populations, as stored in
+        `ts.populations().metadata["name"]`. Multiple source populations are
+        treated as one combined source category.
+    output : str
+        Path to the output BED-like file. An empty file is written when no
+        matching tracts are found.
     is_phased : bool, optional
         Whether to output haplotype-level sample identifiers. Default: True.
     ploidy : int, optional
@@ -286,9 +290,8 @@ def get_true_tracts(
 
     Returns
     -------
-    str
-        A tab-delimited string listing inferred introgressed tracts with columns
-        Chromosome, Start, End, and Sample.
+    None
+        The extracted tracts are written to `output`.
 
     Raises
     ------
@@ -297,9 +300,13 @@ def get_true_tracts(
     """
     header = "Chromosome\tStart\tEnd\tSample\n"
 
-    try:
-        src_pop = [p.id for p in ts.populations() if p.metadata["name"] == src_id][0]
-    except IndexError:
+    if isinstance(src_id, str):
+        src_ids = (src_id,)
+    else:
+        src_ids = tuple(src_id)
+
+    src_pops = [p.id for p in ts.populations() if p.metadata["name"] in src_ids]
+    if not src_pops:
         raise ValueError(f"Population {src_id} is not found.")
 
     try:
@@ -308,10 +315,11 @@ def get_true_tracts(
         raise ValueError(f"Population {tgt_id} is not found.")
 
     # Use NumPy column arrays to select matching migration records once.
-    keep = (ts.migrations_dest == src_pop) & (ts.migrations_source == tgt_pop)
+    keep = np.isin(ts.migrations_dest, src_pops) & (ts.migrations_source == tgt_pop)
 
     if not np.any(keep):
-        return header
+        open(output, "w").close()
+        return
 
     mig_left = ts.migrations_left[keep]
     mig_right = ts.migrations_right[keep]
@@ -346,7 +354,8 @@ def get_true_tracts(
 
     valid = start_tree < end_tree
     if not np.any(valid):
-        return header
+        open(output, "w").close()
+        return
 
     mig_left = mig_left[valid]
     mig_right = mig_right[valid]
@@ -364,7 +373,7 @@ def get_true_tracts(
 
     # Use an insertion-ordered dict as the active migration set.
     active = {}
-    output = [header]
+    tract_lines = [header]
 
     trees = ts.trees(tracked_samples=target_sample_list, sample_lists=True)
 
@@ -407,11 +416,16 @@ def get_true_tracts(
             # with is_descendant.
             for sample_node in tree.samples(ancestor):
                 if is_target_sample[sample_node]:
-                    output.append(
+                    tract_lines.append(
                         f"1\t{int(left)}\t{int(right)}\t"
                         f"{sample_names[sample_node]}\n"
                     )
 
+    if len(tract_lines) == 1:
+        open(output, "w").close()
+        return
+
+    tracts = "".join(tract_lines)
     true_tracts = pr.from_string(tracts).merge(by="Sample")
 
     if true_tracts.empty:


### PR DESCRIPTION
### Motivation
- Remove several runtime/interface bugs in `get_true_tracts` that prevented correct detection of source populations and writing of Snakemake outputs while preserving existing scientific logic and file formats.
- Support workflows with one or two source populations and ensure callers receive outputs via files rather than unused return strings.

### Description
- Change `get_true_tracts` signature to accept `src_id: Union[str, tuple[str, ...], list[str]]` and `output: str`, convert `src_id` to a tuple, and resolve one-or-many source population ids from `ts.populations()`.
- Use `np.isin(ts.migrations_dest, src_pops) & (ts.migrations_source == tgt_pop)` to select migration records, map migration intervals to tree-index ranges with `numpy.searchsorted`, and keep migration direction semantics unchanged.
- Fix data-flow bugs by collecting output lines into `tract_lines` (instead of overwriting the `output` path), joining them into `tracts` before parsing with `pyranges`, and writing an empty output file for all no-tract cases (no matching migrations, no valid intervals, no tract lines, or empty PyRanges).
- Add/adjust related code paths and helpers in the same file to support two source populations (`simulate` and `create_sample_lists` signatures and sample list handling) and update callers to invoke `get_true_tracts(..., output=...)` for the appropriate BED outputs; also update the `get_true_tracts` docstring to reflect file output and `Returns: None`.

### Testing
- Ran formatter check with `black --check workflow/scripts/msprime_simulation.py`, which passed.
- Verified Python syntax with `python -m py_compile workflow/scripts/msprime_simulation.py`, which succeeded.
- Attempted `flake8 workflow/scripts/msprime_simulation.py` but `flake8` is not installed in the environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3805417b84832c8facf5199fcca5b6)